### PR TITLE
feat: Add workflow on PR merged

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -1,0 +1,17 @@
+on:
+  pull_request:
+    branches:
+    - main
+    types: [closed]
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+    - run: |
+        echo "${{ toJSON(github.event) }}"
+    - run: |
+        echo "${{ toJSON(github.event.pull_request) }}"
+      if: contains(github.event.pull_request.labels.*.name, 'enhancement')
+      name: Runs if enhancement label is present

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -54,15 +54,15 @@ jobs:
         committer: 'releasebot <noreply@github.com>'
         branch: 'autorelease/${{ steps.update-changelog.outputs.release-version }}'
         title: '[autorelease] Prepare release ${{ steps.update-changelog.outputs.release-version }}'
-        body: >
-          **This PR was created automatically by the releasebot**
+        body: |
+          **This PR was created automatically by the releasebot on behalf of @${{ env.GITHUB_ACTOR }}**
 
           **NOTE: Approving this PR will trigger a workflow that performs the actual release**
 
           The changes in this PR prepare for release ${{ steps.update-changelog.outputs.release-version }}. They
           include:
 
-          - Update the changelog for the latest release
+          ${{ steps.update-changelog.outputs.release-notes }}
         labels: autorelease
 
     - name: Create Draft Release
@@ -75,4 +75,3 @@ jobs:
         release_name: 'Release ${{ steps.update-changelog.outputs.release-version }}'
         draft: true
         body: ${{ steps.update-changelog.outputs.release-notes }}
-        comitish: main


### PR DESCRIPTION
Adds a `pr-merged.yml` workflow. Currently this just issues some diagnostic information, but it will be modified to include logic for processing the linked release.