### PR TITLE
Automate moving major ref on release publish

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -47,6 +47,10 @@ jobs:
     - name: Update major release ref
       if: ${{ ! fromJSON(steps.get-release-version.outputs.is-prerelease) }}
       run: |
-        git push origin ${{ github.event.release.tag_name }}:${{ steps.get-release-version.outputs.major-ref }}
+        VERSION="${{ github.event.release.tag_name }}"
+        if [[ ! $VERSION ]]; then
+          VERSION="${{ github.event.inputs.release-version }}"
+        fi
+        git push origin $VERSION:${{ steps.get-release-version.outputs.major-ref }}
         echo "::notice::Updated ref ${{ steps.get-release-version.outputs.major-ref }}"
 

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -25,8 +25,6 @@ jobs:
           VERSION="${{ github.event.inputs.release-version }}"
         fi
 
-        echo "VERSION=$VERSION"
-        
         RE='^[vV]?([0-9]+)[.]([0-9]+)[.]([0-9]+)(-[0-9A-Za-z.+-]*)?'
         if [[ $VERSION =~ $RE ]]; then
           MAJOR="${BASH_REMATCH[1]}"
@@ -37,9 +35,17 @@ jobs:
           echo "::error::Version '$VERSION' is not in a valid format" && exit 1
         fi
 
-        echo "MAJOR = $MAJOR"
-        if [[ "$SPECIAL" ]]; then
-          echo "SPECIAL present: $SPECIAL"
-        else
-          echo "No SPECIAL"
-        fi
+        echo "::set-output name=major-ref::v$MAJOR"
+        if [[ "$SPECIAL" ]]; then pre=true; else pre=false; fi
+        echo "::set-output name=is-prerelease::${{ toJSON($pre) }}"
+
+    - name: Print if prerelease
+      if: fromJSON(steps.get-release-version.outputs.is-prerelease)
+      run: |
+        echo "It's a pre-release version"
+
+    - name: Print if prerelease
+      if: ! fromJSON(steps.get-release-version.outputs.is-prerelease)
+      run: |
+        echo "It's **NOT** a pre-release version"
+

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -1,0 +1,49 @@
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: 'Release version'
+        type: string
+        required: true
+
+
+name: '[autorelease] Release published'
+
+jobs:
+  update-ref:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Get release version
+      id: get-release-version
+      run: |
+        function semverParse() {
+            local RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'
+            MAJOR=`echo $1 | sed -e "s#$RE#\1#"`
+            MINOR=`echo $1 | sed -e "s#$RE#\2#"`
+            PATCH=`echo $1 | sed -e "s#$RE#\3#"`
+            SPECIAL=`echo $1 | sed -e "s#$RE#\4#"`
+        }
+
+        VERSION="${{ github.event.release.tag_name }}"
+        if [[ -n "$VERSION" ]]; then
+          VERSION="${{ github.event.inputs.release-version }}"
+        fi
+
+        echo "VERSION=$VERSION"
+        
+        local MAJOR=0
+        local MINOR=0
+        local PATCH=0
+        local SPECIAL=0
+
+        semverParse $VERSION
+        echo "MAJOR = $MAJOR"
+        if [[ "$SPECIAL" ]]; then
+          echo "SPECIAL present: $SPECIAL"
+        else
+          echo "No SPECIAL"
+        fi

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -37,15 +37,15 @@ jobs:
 
         echo "::set-output name=major-ref::v$MAJOR"
         if [[ "$SPECIAL" ]]; then pre=true; else pre=false; fi
-        echo "::set-output name=is-prerelease::${{ toJSON($pre) }}"
+        echo "::set-output name=is-prerelease::${{ toJSON(env.pre) }}"
 
     - name: Print if prerelease
       if: fromJSON(steps.get-release-version.outputs.is-prerelease)
       run: |
-        echo "It's a pre-release version"
+        echo "It's a pre-release version, ref = ${{ steps.get-release-version.outputs.major-ref }}"
 
     - name: Print if prerelease
       if: ! fromJSON(steps.get-release-version.outputs.is-prerelease)
       run: |
-        echo "It's **NOT** a pre-release version"
+        echo "It's **NOT** a pre-release version, ref = ${{ steps.get-release-version.outputs.major-ref }}"
 

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -47,6 +47,6 @@ jobs:
     - name: Update major release ref
       if: ${{ ! fromJSON(steps.get-release-version.outputs.is-prerelease) }}
       run: |
-        git push origin HEAD:${{ steps.get-release-version.outputs.major-ref }}
+        git push origin ${{ github.event.release.tag_name }}:${{ steps.get-release-version.outputs.major-ref }}
         echo "::notice::Updated ref ${{ steps.get-release-version.outputs.major-ref }}"
 

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -20,14 +20,6 @@ jobs:
     - name: Get release version
       id: get-release-version
       run: |
-        function semverParse() {
-            local RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'
-            MAJOR=`echo $1 | sed -e "s#$RE#\1#"`
-            MINOR=`echo $1 | sed -e "s#$RE#\2#"`
-            PATCH=`echo $1 | sed -e "s#$RE#\3#"`
-            SPECIAL=`echo $1 | sed -e "s#$RE#\4#"`
-        }
-
         VERSION="${{ github.event.release.tag_name }}"
         if [[ ! $VERSION ]]; then
           VERSION="${{ github.event.inputs.release-version }}"
@@ -35,11 +27,15 @@ jobs:
 
         echo "VERSION=$VERSION"
         
-        RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'
-        MAJOR=`echo $VERSION | sed -e "s#$RE#\1#"`
-        MINOR=`echo $VERSION | sed -e "s#$RE#\2#"`
-        PATCH=`echo $VERSION | sed -e "s#$RE#\3#"`
-        SPECIAL=`echo $VERSION | sed -e "s#$RE#\4#"`
+        RE='^[vV]?([0-9]+)[.]([0-9]+)[.]([0-9]+)(-[0-9A-Za-z.+-]*)?'
+        if [[ $VERSION =~ $RE ]]; then
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+          PATCH="${BASH_REMATCH[3]}"
+          SPECIAL="${BASH_REMATCH[4]}"
+        else
+          echo "::error::Version '$VERSION' is not in a valid format" && exit 1
+        fi
 
         echo "MAJOR = $MAJOR"
         if [[ "$SPECIAL" ]]; then

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -34,8 +34,8 @@ jobs:
         fi
 
         echo "::set-output name=major-ref::v$MAJOR"
-        if [[ "$SPECIAL" ]]; then echo "pre=true" >> GITHUB_ENV; else echo "pre=false" >> GITHUB_ENV; fi
-        echo "::set-output name=is-prerelease::${{ toJSON(env.pre) }}"
+        if [[ "$SPECIAL" ]]; then pre=true; else pre=false; fi
+        echo "::set-output name=is-prerelease::$pre"
 
     - name: Print if prerelease
       if: fromJSON(steps.get-release-version.outputs.is-prerelease)

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -15,8 +15,6 @@ jobs:
   update-ref:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-
     - name: Get release version
       id: get-release-version
       run: |
@@ -42,10 +40,10 @@ jobs:
     - name: Print if prerelease
       if: fromJSON(steps.get-release-version.outputs.is-prerelease)
       run: |
-        echo "It's a pre-release version, ref = ${{ steps.get-release-version.outputs.major-ref }}"
+        echo "It's a pre-release version (${{ steps.get-release-version.outputs.is-prerelease }}), ref = ${{ steps.get-release-version.outputs.major-ref }}"
 
     - name: Print if not prerelease
       if: ${{ ! fromJSON(steps.get-release-version.outputs.is-prerelease) }}
       run: |
-        echo "It's **NOT** a pre-release version, ref = ${{ steps.get-release-version.outputs.major-ref }}"
+        echo "It's **NOT** a pre-release version (${{ steps.get-release-version.outputs.is-prerelease }}), ref = ${{ steps.get-release-version.outputs.major-ref }}"
 

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -36,7 +36,7 @@ jobs:
         fi
 
         echo "::set-output name=major-ref::v$MAJOR"
-        if [[ "$SPECIAL" ]]; then pre=true; else pre=false; fi
+        if [[ "$SPECIAL" ]]; then echo "pre=true" >> GITHUB_ENV; else echo "pre=false" >> GITHUB_ENV; fi
         echo "::set-output name=is-prerelease::${{ toJSON(env.pre) }}"
 
     - name: Print if prerelease
@@ -44,7 +44,7 @@ jobs:
       run: |
         echo "It's a pre-release version, ref = ${{ steps.get-release-version.outputs.major-ref }}"
 
-    - name: Print if prerelease
+    - name: Print if not prerelease
       if: ${{ ! fromJSON(steps.get-release-version.outputs.is-prerelease) }}
       run: |
         echo "It's **NOT** a pre-release version, ref = ${{ steps.get-release-version.outputs.major-ref }}"

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -15,6 +15,8 @@ jobs:
   update-ref:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v3
+
     - name: Get release version
       id: get-release-version
       run: |
@@ -28,22 +30,23 @@ jobs:
           MAJOR="${BASH_REMATCH[1]}"
           MINOR="${BASH_REMATCH[2]}"
           PATCH="${BASH_REMATCH[3]}"
-          SPECIAL="${BASH_REMATCH[4]}"
+          PRERELEASE="${BASH_REMATCH[4]}"
         else
           echo "::error::Version '$VERSION' is not in a valid format" && exit 1
         fi
 
         echo "::set-output name=major-ref::v$MAJOR"
-        if [[ "$SPECIAL" ]]; then pre=true; else pre=false; fi
+        if [[ "$PRERELEASE" ]]; then pre=true; else pre=false; fi
         echo "::set-output name=is-prerelease::$pre"
 
-    - name: Print if prerelease
+    - name: Prerelease
       if: fromJSON(steps.get-release-version.outputs.is-prerelease)
       run: |
-        echo "It's a pre-release version (${{ steps.get-release-version.outputs.is-prerelease }}), ref = ${{ steps.get-release-version.outputs.major-ref }}"
+        echo "::notice::Pre-release version detected, not moving ref  ${{ steps.get-release-version.outputs.major-ref }}"
 
-    - name: Print if not prerelease
+    - name: Update major release ref
       if: ${{ ! fromJSON(steps.get-release-version.outputs.is-prerelease) }}
       run: |
-        echo "It's **NOT** a pre-release version (${{ steps.get-release-version.outputs.is-prerelease }}), ref = ${{ steps.get-release-version.outputs.major-ref }}"
+        git push origin HEAD:${{ steps.get-release-version.outputs.major-ref }}
+        echo "::notice::Updated ref ${{ steps.get-release-version.outputs.major-ref }}"
 

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -29,18 +29,18 @@ jobs:
         }
 
         VERSION="${{ github.event.release.tag_name }}"
-        if [[ -n "$VERSION" ]]; then
+        if [[ ! $VERSION ]]; then
           VERSION="${{ github.event.inputs.release-version }}"
         fi
 
         echo "VERSION=$VERSION"
         
-        local MAJOR=0
-        local MINOR=0
-        local PATCH=0
-        local SPECIAL=0
+        RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'
+        MAJOR=`echo $VERSION | sed -e "s#$RE#\1#"`
+        MINOR=`echo $VERSION | sed -e "s#$RE#\2#"`
+        PATCH=`echo $VERSION | sed -e "s#$RE#\3#"`
+        SPECIAL=`echo $VERSION | sed -e "s#$RE#\4#"`
 
-        semverParse $VERSION
         echo "MAJOR = $MAJOR"
         if [[ "$SPECIAL" ]]; then
           echo "SPECIAL present: $SPECIAL"

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Get release version
       id: get-release-version

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -45,7 +45,7 @@ jobs:
         echo "It's a pre-release version, ref = ${{ steps.get-release-version.outputs.major-ref }}"
 
     - name: Print if prerelease
-      if: ! fromJSON(steps.get-release-version.outputs.is-prerelease)
+      if: ${{ ! fromJSON(steps.get-release-version.outputs.is-prerelease) }}
       run: |
         echo "It's **NOT** a pre-release version, ref = ${{ steps.get-release-version.outputs.major-ref }}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- Automatically bump the major ref (e.g. `v1`) when a release is published
+
 ## [0.1.0] - 2022-03-14
 
 ### Fixed


### PR DESCRIPTION
Closes #12 

Adds a workflow to automatically move the version ref (e.g. `v1`) when a release is published.