### PR TITLE
fix: Ensure major ref is a branch not tag

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -53,6 +53,6 @@ jobs:
         if [[ ! $VERSION ]]; then
           VERSION="${{ github.event.inputs.release-version }}"
         fi
-        git push origin $VERSION:${{ steps.get-release-version.outputs.major-ref }}
+        git push origin $VERSION:refs/tags/${{ steps.get-release-version.outputs.major-ref }}
         echo "::notice::Updated ref ${{ steps.get-release-version.outputs.major-ref }}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Ensure push to branch not tag
+
 ## [0.2.0] - 2022-03-25
 
 ### Added


### PR DESCRIPTION
By default, `git push` will create a destination ref that matches the type of the source ref. As we are pushing the tag, this means it will, by default, create a major version tag instead of a branch. We want to create a branch, so this PR is to ensure that.